### PR TITLE
[PES-974] Allow users to specify a custom CloudWatch log group for the CodeBuild project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.94.1 |
 
 ## Modules
 
@@ -46,6 +46,7 @@
 | <a name="input_build_type"></a> [build\_type](#input\_build\_type) | Type of build environment to use for related builds. | `string` | `"LINUX_CONTAINER"` | no |
 | <a name="input_buildspec"></a> [buildspec](#input\_buildspec) | The build spec declaration to use for this build project's related builds. | `string` | `""` | no |
 | <a name="input_cache"></a> [cache](#input\_cache) | Cache configuration block. | <pre>object({<br>    type     = optional(string)       # Valid values: NO_CACHE, LOCAL, S3. Defaults to NO_CACHE.<br>    modes    = optional(list(string)) # Required when cache type is LOCAL<br>    location = optional(string)       # Required when cache type is S3<br>  })</pre> | `{}` | no |
+| <a name="input_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#input\_cloudwatch\_log\_group) | Custom log group for CodeBuild Project | `string` | `null` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Create new IAM service role and policy if `true`. | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Short description of the project. | `string` | n/a | yes |
 | <a name="input_encryption_key_arn"></a> [encryption\_key\_arn](#input\_encryption\_key\_arn) | AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts. | `string` | `null` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,5 @@
 module "codebuild_service_role" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.2.0"
 
@@ -17,6 +18,7 @@ module "codebuild_service_role" {
 }
 
 module "codebuild_service_role_policy" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "~> 5.2.0"
 

--- a/main.tf
+++ b/main.tf
@@ -42,4 +42,11 @@ resource "aws_codebuild_project" "this" {
     location            = var.source_location
     report_build_status = var.report_build_status
   }
+
+  logs_config {
+    cloudwatch_logs {
+      group_name = var.cloudwatch_log_group != null ? var.cloudwatch_log_group : null
+      status = "ENABLED"
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,8 @@ resource "aws_codebuild_project" "this" {
 
   logs_config {
     cloudwatch_logs {
-      group_name = var.cloudwatch_log_group != null ? var.cloudwatch_log_group : null
-      status = "ENABLED"
+      group_name = var.cloudwatch_log_group != null && var.cloudwatch_log_group != "" ? var.cloudwatch_log_group : null
+      status     = "ENABLED"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,6 @@ variable "additional_iam" {
 
 variable "cloudwatch_log_group" {
   description = "Custom log group for CodeBuild Project"
-  type = string
-  default = null
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,9 @@ variable "additional_iam" {
   type        = list(any)
   default     = []
 }
+
+variable "cloudwatch_log_group" {
+  description = "Custom log group for CodeBuild Project"
+  type = string
+  default = null
+}


### PR DESCRIPTION
Allow users to specify a custom CloudWatch log group for the CodeBuild project.
If no log group is provided, a default one will be automatically created by the aws_codebuild_project resource.